### PR TITLE
build: provide docker and compose file for running as a container

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -5,6 +5,7 @@ ENABLED_SCRAPING_STRATEGIES="hays,freelance-de,michael-page"
 ### GENERAL CONFIGURATION
 DEBUG="false"
 DATABASE_ENABLED="true"
+DATABASE_FILE_PATH="./database/re-employment-kraken.db"
 LOG_HTTP_RESPONSE="false"
 
 ### NOTIFIERS

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ database
 .linked-in-posts.md
 node_modules
 response.html
+.idea
+deploy.sh
+*.tar
+run.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:20.9.0-alpine3.18
+
+WORKDIR /usr/src/app
+
+# Install dependencies.
+COPY package*.json ./
+RUN npm install
+
+# Copy required source code. Do not include config and database files. Those should be mounted as volumes.
+COPY lib/ ./lib/
+COPY *.js ./
+
+CMD ["npm", "start"]

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,9 @@
+version: '2'
+
+services:
+  re-employment-kraken:
+    image: re-employment-kraken:latest
+    container_name: re-employment-kraken
+    volumes:
+      - ./.env:/usr/src/app/.env:ro
+      - ./database/:/usr/src/app/database/

--- a/config.js
+++ b/config.js
@@ -26,6 +26,7 @@ export const config = {
   mode: "sequential",
   database: {
     enabled: process.env.DATABASE_ENABLED === "true",
+    filePath: process.env.DATABASE_FILE_PATH,
   },
   fetchConfig: {
     headers: {

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 import { config } from "./config.js"
 import { fetch } from "./lib/fetch.js"
 import { process as processStrategy } from "./lib/process.js"
-import { initDB, closeDB, DB_PERSISTENT, DB_IN_MEMORY } from "./lib/db.js"
+import { initDB, closeDB, DB_IN_MEMORY } from "./lib/db.js"
 
 const scrape = async (config) => {
   const { mode, scrapingStrategies, queries } = config
@@ -23,7 +23,7 @@ process.on('unhandledRejection', (reason) => {
 
 try {
   // In case the database flag is turned off, we fall back to an in-memory DB for temporary deduplication.
-  await initDB(config.database.enabled ? DB_PERSISTENT : DB_IN_MEMORY)
+  await initDB(config.database.enabled ? config.database.filePath : DB_IN_MEMORY)
   await scrape(config)
 } catch (err) {
   console.error(`An unexpected error occurred: ${err.message}`)

--- a/lib/db.js
+++ b/lib/db.js
@@ -1,8 +1,9 @@
 import sqlite3 from 'sqlite3'
 import joi from 'joi'
+import fs from 'fs'
+import path from 'path'
 
-// The constants below can be passed to initDB to create a persistent or in-memory database.
-export const DB_PERSISTENT = "re-employment-kraken.db"
+// DB_IN_MEMORY can be passed to initDB to create an in-memory database without lasting persistence.
 export const DB_IN_MEMORY = ":memory:"
 
 // Due to simplicity, all schema definition steps are defined below. Depending on required future changes,
@@ -35,9 +36,18 @@ let db = null
 
 // initDB MUST be called once before any interaction with the database occurs (e.g. on application startup).
 // It returns a Promise that resolves when the database has been prepared successfully.
-export const initDB = async (dbConnectionString) => {
+export const initDB = async (dbFilePath) => {
+    if (dbFilePath !== DB_IN_MEMORY) {
+        const dir = path.dirname(dbFilePath)
+
+        if (!fs.existsSync(dir)) {
+            fs.mkdirSync(dir, { recursive: true })
+        }
+        // DB file will be created automatically as the target directory exists.
+    }
+
     return new Promise((resolve, reject) => {
-        db = new sqlite3.Database(dbConnectionString, (err) => {
+        db = new sqlite3.Database(dbFilePath, (err) => {
             if (err) {
                 reject(new Error(`Error on creating database connection: ${err.message}`))
                 return


### PR DESCRIPTION
* Add Dockerfile for container building (pass .env and DB file as volumes).
* Make DB file and path configurable to allow provisioning as volume.
* Add compose.yml file for simple container start with required volumes.
* Document how to run as a container (align existing how to run section).